### PR TITLE
Adds setup files

### DIFF
--- a/beanborg/bb_archive.py
+++ b/beanborg/bb_archive.py
@@ -4,14 +4,15 @@
 __copyright__ = "Copyright (C) 2021  Luciano Fiandesio"
 __license__ = "GNU GPLv2"
 
-import argparse
 import csv
 import os
-from datetime import datetime
-import sys
 import shutil
-from config import *
-from arg_parser import *
+import sys
+from datetime import datetime
+
+from beanborg.arg_parser import eval_args
+from beanborg.config import init_config
+
 
 def main():
 

--- a/beanborg/bb_import.py
+++ b/beanborg/bb_import.py
@@ -5,23 +5,23 @@ __copyright__ = "Copyright (C) 2021  Luciano Fiandesio"
 __license__ = "GNU GPLv2"
 
 import csv
-from datetime import datetime, timedelta
 import hashlib
 import os
 import os.path
-import sys
 import random
+import sys
 import traceback
-from config import *
-from arg_parser import *
-from beancount.parser.printer import format_entry
-from beancount.core.data import Transaction, Amount, Posting
-from beancount.core.number import D
-import beancount.loader as loader
+from datetime import datetime, timedelta
 
-from rule_engine.rules_engine import RuleEngine
-from rule_engine.Context import Context
-from rule_engine.decision_tables import init_decision_table
+import beancount.loader as loader
+from beancount.core.data import Transaction, Amount
+from beancount.core.number import D
+from beancount.parser.printer import format_entry
+
+from beanborg.arg_parser import eval_args
+from beanborg.config import init_config
+from beanborg.rule_engine.Context import Context
+from beanborg.rule_engine.rules_engine import RuleEngine
 
 
 def gen_datetime(min_year=1900, max_year=datetime.now().year):

--- a/beanborg/bb_mover.py
+++ b/beanborg/bb_mover.py
@@ -4,13 +4,13 @@
 __copyright__ = "Copyright (C) 2021  Luciano Fiandesio"
 __license__ = "GNU GPLv2"
 
-import argparse
+import glob
 import os
 import sys
-import glob
-import yaml
-from config import *
-from arg_parser import *
+
+from beanborg.arg_parser import eval_args
+from beanborg.config import init_config
+
 
 def main():
     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = [
+    "setuptools>=42",
+    "wheel",
+    "setuptools_scm[toml]>=3.4",
+]
+
+[tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,14 @@
+[metadata]
+name = beanborg
+url = https://github.com/luciano-fiandesio/beanborg
+author = Luciano Fiandesio
+author_email = luciano@fiandes.io
+description = Beanborg automatically imports financial transactions from external CSV files into the Beancount bookkeeping system.
+
+[options]
+include_package_data = True
+packages =
+    beanborg
+install_requires =
+    beancount==2.3.3
+    pyyaml==5.4.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,9 @@ packages =
 install_requires =
     beancount==2.3.3
     pyyaml==5.4.1
+
+[options.entry_points]
+console_scripts =
+    bb_mover = beanborg:bb_mover.main
+    bb_archive = beanborg:bb_archive.main
+    bb_import = beanborg:bb_import.main

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+import setuptools
+
+# just a minimal setup.py file for backwards compatibility. Actual config is done in setup.cfg.
+setuptools.setup()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,25 @@
+[tox]
+envlist = py{36,37,38,39}
+
+# Activate isolated build environment. tox will use a virtual environment
+# to build a source distribution from the source tree. For build tools and
+# arguments use the pyproject.toml file as specified in PEP-517 and PEP-518.
+isolated_build = true
+
+[testenv]
+deps =
+    # If your project uses README.rst, uncomment the following:
+    # readme_renderer
+    flake8
+    pytest
+commands =
+    # This repository uses a Markdown long_description, so the -r flag to
+    # `setup.py check` is not needed. If your project contains a README.rst,
+    # use `python setup.py check -m -r -s` instead.
+    #python setup.py check -m -s
+    # flake8 .
+    py.test tests {posargs}
+
+[flake8]
+exclude = .tox,*.egg,build,data
+select = E,W,F


### PR DESCRIPTION
I tried to use the state of the art as described by the PyPA. Additionally I also used setuptools_scm to auto-generate version info. Additional benefit is that is simplifies package data management, so no need to maintain a manifest (not applicable here, because AFAIK there is no package data).

To build sdist and bdist wheels run install https://pypi.org/project/build/ and then run `python -m build --sdist --wheel .`

To version the package create tags on the master branch. (see setuptools_scm documentation for details)

I filled in the metadata to the best of my knowledge.

@luciano-fiandesio Let me know if this is useful or if you have questions.