### PR TITLE
Add `post_move_script` to post-process file

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Here are the list of options for the `csv` section:
 | skip          | Number of lines of the CSV file to skip during import                                                                                                    | 1       |                     |
 | target        | The folder name or path in which the CSV file is moved to during the first stage.    s                                                                                                            | tmp     |                     |
 | archive       | The folder name of path in which the CSV file is archived during the archive stage                                                                                                               | archive |                     |
+| post_move_script       | Path to a post-move script that is executed after the CSV file is moved into the work folder. The script must use a `shebang` (e.g. `#!/bin/bash`) in order to be executed.|  |`/home/tom/scripts/convert.sh` |
 
 #### indexes
 

--- a/beanborg/bb_mover.py
+++ b/beanborg/bb_mover.py
@@ -39,7 +39,7 @@ def main():
 
     for f in os.listdir(config.csv.download_path):
         if f.startswith(config.csv.name):
-            moved_csv = os.path.join(config.csv.target, config.csv.ref + ".csv")  #config.csv.target + "/" + config.csv.ref + ".csv"
+            moved_csv = os.path.join(config.csv.target, config.csv.ref + ".csv")
             os.rename(config.csv.download_path + "/" + f, moved_csv)
             if(config.csv.post_script_path):
                 try:

--- a/beanborg/bb_mover.py
+++ b/beanborg/bb_mover.py
@@ -7,16 +7,17 @@ __license__ = "GNU GPLv2"
 import glob
 import os
 import sys
+from subprocess import check_call, CalledProcessError
 
 from beanborg.arg_parser import eval_args
 from beanborg.config import init_config
-
 
 def main():
     
     args = eval_args('Move bank csv file to processing folder')
     config = init_config(args.file, args.debug)
-    
+    current_dir = os.getcwd()
+
     if not os.path.isdir(config.csv.download_path):
         print("folder: %s does not exist!"%(config.csv.download_path))
         sys.exit(-1)
@@ -38,8 +39,13 @@ def main():
 
     for f in os.listdir(config.csv.download_path):
         if f.startswith(config.csv.name):
-            os.rename(config.csv.download_path + "/" + f, config.csv.target + "/" + config.csv.ref + ".csv")
-
+            moved_csv = os.path.join(config.csv.target, config.csv.ref + ".csv")  #config.csv.target + "/" + config.csv.ref + ".csv"
+            os.rename(config.csv.download_path + "/" + f, moved_csv)
+            if(config.csv.post_script_path):
+                try:
+                    check_call([config.csv.post_script_path, os.path.join(current_dir, moved_csv)])
+                except CalledProcessError as e:
+                    print("An error occurred executing: %s\n%s"%(config.csv.post_script_path, str(e)))
     print("Done :) ")
 
 

--- a/beanborg/config.py
+++ b/beanborg/config.py
@@ -30,7 +30,7 @@ class Indexes(object):
 
 class Csv(object):
 
-    def __init__(self, download_path, name, ref, separator=None, currency_sep=None, date_format=None, skip=None, target=None, archive=None):
+    def __init__(self, download_path, name, ref, separator=None, currency_sep=None, date_format=None, skip=None, target=None, archive=None, post_script_path=None):
         self.download_path = download_path
         self.name = name
         self.ref = ref
@@ -40,6 +40,7 @@ class Csv(object):
         self.skip = skip
         self.target = target
         self.archive = archive
+        self.post_script_path = post_script_path
 
 class Config(object):
 
@@ -63,7 +64,8 @@ class Config(object):
             csv_data['date_format'],
             csv_data.get('skip', 1),
             csv_data.get('target', 'tmp'),
-            csv_data.get('archive_path', 'archive')
+            csv_data.get('archive_path', 'archive'),
+            csv_data.get('post_move_script')
         )
 
         idx = values.get('indexes', dict()) 


### PR DESCRIPTION
`post_move_script` allow to specify a path to a script that
is executed after the file is moved to the target directory.