### PR TITLE
fix: python -m "build" failed on missing requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-beancount==2.3.3
-pyyaml==6.0.1
-rich==13.6.0
-prompt-toolkit==3.0.39

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,5 @@
 from setuptools import setup, find_packages
 
-# Read requirements.txt
-with open('requirements.txt') as f:
-    required = f.read().splitlines()
-
 setup(
     name='beanborg',
     version='0.1',
@@ -11,7 +7,12 @@ setup(
     author_email='luciano@fiandes.io',
     url='https://github.com/luciano-fiandesio/beanborg',
     packages=find_packages(),
-    install_requires=required,
+    install_requires=[
+       "beancount==2.3.3",
+       "pyyaml==6.0.1",
+       "rich==13.6.0",
+       "prompt-toolkit==3.0.39",
+    ],
     entry_points={
         'console_scripts': [
         	'bb_mover=beanborg:bb_mover.main',


### PR DESCRIPTION
The setup includes this file, but python build doesn't copy that into a pristine env so during building the file is not there.

This commit removes the requirements.txt entirely and moves the requirements into the setup.py

**NOTE**: build mightn't be needed at all, I just encountered this issue when debugging #19 and saw that the build was failing. 
I'm also not sure if removing the requirements.txt is warranted, maybe some people or processes depend on it?