### PR TITLE
Update Beancount version dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-beancount==2.3.3
+beancount>=2.3.3, <3.0.0
 pyyaml==6.0.1
 rich==13.6.0
 prompt-toolkit==3.0.39


### PR DESCRIPTION
Made the dependency flexible (<3.0.0) to avoid this issue in the future, but feel free to change this if you disagree of course.