### PR TITLE
feat: support multiple accounts in Replace Expense rule

### DIFF
--- a/beanborg/rule_engine/rules.py
+++ b/beanborg/rule_engine/rules.py
@@ -183,7 +183,7 @@ class Replace_Expense(Rule):
     Categorizes a transaction by assigning the account extracted from a look-up table
     based on the 'payee_pos' index of a CSV file row.
 
-    The rule is based on the 'payee.rules' look-up file.
+    The rule is based on the 'account.rules' look-up file.
     """
     def __init__(self, name, context):
         Rule.__init__(self, name, context)
@@ -199,6 +199,7 @@ class Replace_Expense(Rule):
             LookUpCache.init_decision_table("account", table),
             csv_line[self.context.payee_pos],
             self.context.default_expense,
+            self.context.account
         )
         if expense:
             posting = Posting(expense, None, None, None, None, None)

--- a/beanborg/rule_engine/rules_engine.py
+++ b/beanborg/rule_engine/rules_engine.py
@@ -30,10 +30,6 @@ class RuleDef:
     def get(self, key):
         return self.attributes[key]
 
-
-
-
-
 class Rule_Init(Rule):
     def __init__(self, name, context):
         Rule.__init__(self, name, context)
@@ -79,7 +75,6 @@ class RuleEngine:
         return cr
 
     def __init__(self, ctx: Context):
-
         self._ctx = ctx
         self.rules = {}
 

--- a/tests/files/account.rules
+++ b/tests/files/account.rules
@@ -1,2 +1,5 @@
 value;expression;result
 freshfood;sw;Expenses:Groceries
+books;contains_ic;Expenses:John:Books
+books;contains_ic;Expenses:Multimedia:Books;visa
+

--- a/tests/files/bank1.yaml
+++ b/tests/files/bank1.yaml
@@ -21,7 +21,6 @@ indexes:
   
 rules:
   beancount_file: 'main1.ldg'
-  #rules_file: luciano.amex.rules
   account: '1234567'
   currency: GBP
   default_expense: 'Expense:Magic'

--- a/tests/files/bank1_custom_rule.yaml
+++ b/tests/files/bank1_custom_rule.yaml
@@ -21,7 +21,6 @@ indexes:
   
 rules:
   beancount_file: 'main1.ldg'
-  #rules_file: luciano.amex.rules
   account: '1234567'
   currency: GBP
   default_expense: 'Expense:Magic'

--- a/tests/files/bank1_ignore_at_pos.yaml
+++ b/tests/files/bank1_ignore_at_pos.yaml
@@ -21,7 +21,6 @@ indexes:
   
 rules:
   beancount_file: 'main1.ldg'
-  #rules_file: luciano.amex.rules
   account: '1234567'
   currency: GBP
   default_expense: 'Expense:Magic'

--- a/tests/files/bank1_ignore_contains_string_at_pos.yaml
+++ b/tests/files/bank1_ignore_contains_string_at_pos.yaml
@@ -21,7 +21,6 @@ indexes:
   
 rules:
   beancount_file: 'main1.ldg'
-  #rules_file: luciano.amex.rules
   account: '1234567'
   currency: GBP
   default_expense: 'Expense:Magic'

--- a/tests/files/bank1_replace_asset.yaml
+++ b/tests/files/bank1_replace_asset.yaml
@@ -21,8 +21,6 @@ indexes:
   
 rules:
   beancount_file: 'main1.ldg'
-  #rules_file: luciano.amex.rules
-  account: '1234567'
   currency: GBP
   default_expense: 'Expense:Magic'
   force_negative: true

--- a/tests/files/bank1_replace_counterparty.yaml
+++ b/tests/files/bank1_replace_counterparty.yaml
@@ -21,7 +21,6 @@ indexes:
   
 rules:
   beancount_file: 'main1.ldg'
-  #rules_file: luciano.amex.rules
   account: '1234567'
   currency: GBP
   default_expense: 'Expense:Magic'

--- a/tests/files/bank1_replace_expense.yaml
+++ b/tests/files/bank1_replace_expense.yaml
@@ -21,7 +21,6 @@ indexes:
   
 rules:
   beancount_file: 'main1.ldg'
-  #rules_file: luciano.amex.rules
   account: '1234567'
   currency: GBP
   default_expense: 'Expense:Magic'

--- a/tests/files/bank1_replace_expense2.yaml
+++ b/tests/files/bank1_replace_expense2.yaml
@@ -21,13 +21,10 @@ indexes:
   
 rules:
   beancount_file: 'main1.ldg'
-  account: '1234567'
+  account: 'visa'
   currency: GBP
   default_expense: 'Expense:Magic'
   force_negative: true
   invert_negative: true
   ruleset:
-    - name: Ignore_By_Payee
-      ignore_payee:
-        - alfa
-        - beta
+    - name: Replace_Expense

--- a/tests/test_decision_tables.py
+++ b/tests/test_decision_tables.py
@@ -1,42 +1,37 @@
 from beanborg.rule_engine.decision_tables import *
-
+from typing import Dict, List
 
 def test_equal_value():
-    table = {}
-    table["superman"] = ("equals", "batman")
+    table: Dict[str, List[Tuple]] = {"superman": [("equals", "batman")]}
     assert "batman" == resolve_from_decision_table(table, "superman", "mini")
 
 def test_equal_value_different_case():
-    table = {}
-    table["superman"] = ("equals", "batman")
+    table: Dict[str, List[Tuple]] = {"superman": [("equals", "batman")]}
     assert "Batman" != resolve_from_decision_table(table, "superman", "mini")
 
 def test_equal_value_ignore_different_case():
-    table = {}
-    table["rewe"] = ("equals_ic", "Expenses:Groceries")
+    table: Dict[str, List[Tuple]] = {"rewe": [("equals_ic", "Expenses:Groceries")]}
+    
+    # table: Dict[str, List[Tuple]] = {} 
+    # table["rewe"] = ("equals_ic", "Expenses:Groceries")
     assert "Expenses:Groceries" == resolve_from_decision_table(table, "rewe", "Expenses:Unknown")
 
 def test_startsWith_value():
-    table = {}
-    table["superman"] = ("startsWith", "batman")
+    table: Dict[str, List[Tuple]] = {"superman": [("startsWith", "batman")]}
     assert "batman" == resolve_from_decision_table(table, "superman_is_cool", "mini")
 
 def test_endsWith_value():
-    table = {}
-    table["superman"] = ("endsWith", "batman")
+    table: Dict[str, List[Tuple]] = {"superman": [("endsWith", "batman")]}
     assert "batman" == resolve_from_decision_table(table, "hello_superman", "mini")
 
 def test_contains_value():
-    table = {}
-    table["superman"] = ("contains", "batman")
+    table: Dict[str, List[Tuple]] = {"superman": [("contains", "batman")]}
     assert "batman" == resolve_from_decision_table(
         table, "hello_superman_hello", "mini"
     )
 
 def test_contains_value_ignore_case():
-    table = {}
-    table["rewe"] = ("contains_ic", "Expenses:Groceries")
-    
+    table: Dict[str, List[Tuple]] = {"rewe": [("contains_ic", "Expenses:Groceries")]}
     assert "Expenses:Groceries" == resolve_from_decision_table(
         table, "card transaction - supermarket REWE", "Expenses:Unknown"
     )
@@ -44,6 +39,6 @@ def test_contains_value_ignore_case():
 def test_loadfile():
     table = init_decision_table("tests/files/payee_with_comments.rules")
     assert table["ford"] != None
-    assert table["ford"][0] == "contains"
-    assert table["ford"][1] == "Ford Auto"
+    assert table["ford"][0][0] == "contains"
+    assert table["ford"][0][1] == "Ford Auto"
     

--- a/tests/test_rules_engine.py
+++ b/tests/test_rules_engine.py
@@ -27,6 +27,15 @@ def test_expense_replacement():
     tx = rule_engine.execute(entries)
     assert tx.postings[1].account == "Expenses:Groceries"
 
+def test_expense_replacement2():
+
+    rule_engine = make_rule_engine('tests/files/bank1_replace_expense2.yaml')
+    entries = "31.10.2019,b,auszahlung,books,x,ZZ03100400000608903100".split(
+        ","
+    )
+    tx = rule_engine.execute(entries)
+    assert tx.postings[1].account == "Expenses:Multimedia:Books"
+
 def test_ignore():
 
     rule_engine = make_rule_engine('tests/files/bank1_ignore_by_counterparty.yaml')
@@ -89,12 +98,11 @@ def test_no_rulefile():
 
 def make_rule_engine(config_file):
     config = init_config(config_file, False)
-    
     return RuleEngine(
         Context(
             ruleset=config.rules.ruleset,
             rules_dir="tests/files",
-            account=None,
+            account=config.rules.account,
             date_fomat="%d.%m.%Y",
             default_expense="Expenses:Unknown",
             date_pos=0,


### PR DESCRIPTION
In scenarios where the same counterparty should be categorized differently based on the account (e.g., business vs. personal expenses), the rule can distinguish based on the `rules.account` property of the yaml configuration file.

- Improved README file